### PR TITLE
Implement Room database for leaderboard

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.kotlin.kapt)
 }
 
 android {
@@ -73,5 +74,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    kapt(libs.androidx.room.compiler)
 
 }

--- a/app/src/main/java/com/supdevinci/trivialquizz/data/local/Converters.kt
+++ b/app/src/main/java/com/supdevinci/trivialquizz/data/local/Converters.kt
@@ -1,0 +1,12 @@
+package com.supdevinci.trivialquizz.data.local
+
+import androidx.room.TypeConverter
+import java.util.Date
+
+class Converters {
+    @TypeConverter
+    fun fromTimestamp(value: Long?): Date? = value?.let { Date(it) }
+
+    @TypeConverter
+    fun dateToTimestamp(date: Date?): Long? = date?.time
+}

--- a/app/src/main/java/com/supdevinci/trivialquizz/data/local/ScoreDao.kt
+++ b/app/src/main/java/com/supdevinci/trivialquizz/data/local/ScoreDao.kt
@@ -1,0 +1,18 @@
+package com.supdevinci.trivialquizz.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ScoreDao {
+    @Insert
+    suspend fun insert(score: ScoreEntity)
+
+    @Query("SELECT * FROM scores ORDER BY percentage DESC, date DESC")
+    fun getAllScores(): Flow<List<ScoreEntity>>
+
+    @Query("DELETE FROM scores")
+    suspend fun clearScores()
+}

--- a/app/src/main/java/com/supdevinci/trivialquizz/data/local/ScoreDatabase.kt
+++ b/app/src/main/java/com/supdevinci/trivialquizz/data/local/ScoreDatabase.kt
@@ -1,0 +1,30 @@
+package com.supdevinci.trivialquizz.data.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(entities = [ScoreEntity::class], version = 1, exportSchema = false)
+@TypeConverters(Converters::class)
+abstract class ScoreDatabase : RoomDatabase() {
+    abstract fun scoreDao(): ScoreDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: ScoreDatabase? = null
+
+        fun getDatabase(context: Context): ScoreDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    ScoreDatabase::class.java,
+                    "scores.db"
+                ).build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/supdevinci/trivialquizz/data/local/ScoreEntity.kt
+++ b/app/src/main/java/com/supdevinci/trivialquizz/data/local/ScoreEntity.kt
@@ -1,0 +1,16 @@
+package com.supdevinci.trivialquizz.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.Date
+
+@Entity(tableName = "scores")
+data class ScoreEntity(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val player: String,
+    val category: String,
+    val difficulty: String,
+    val score: String,
+    val percentage: Int,
+    val date: Date
+)

--- a/app/src/main/java/com/supdevinci/trivialquizz/data/local/ScoreRepository.kt
+++ b/app/src/main/java/com/supdevinci/trivialquizz/data/local/ScoreRepository.kt
@@ -1,0 +1,11 @@
+package com.supdevinci.trivialquizz.data.local
+
+import kotlinx.coroutines.flow.Flow
+
+class ScoreRepository(private val dao: ScoreDao) {
+    val allScores: Flow<List<ScoreEntity>> = dao.getAllScores()
+
+    suspend fun insert(score: ScoreEntity) = dao.insert(score)
+
+    suspend fun clear() = dao.clearScores()
+}

--- a/app/src/main/java/com/supdevinci/trivialquizz/view/LeaderboardScreen.kt
+++ b/app/src/main/java/com/supdevinci/trivialquizz/view/LeaderboardScreen.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.ViewModelProvider
+import androidx.activity.viewModels
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import com.supdevinci.trivialquizz.viewmodel.LeaderboardViewModel
 import com.supdevinci.trivialquizz.model.ScoreEntry
 import com.supdevinci.trivialquizz.ui.theme.TrivialQuizzTheme
@@ -28,21 +30,20 @@ import androidx.compose.ui.text.style.TextOverflow
 
 class LeaderboardActivity : ComponentActivity() {
 
-    private lateinit var leaderboardViewModel: LeaderboardViewModel
+    private val leaderboardViewModel: LeaderboardViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-
-        leaderboardViewModel = ViewModelProvider(this)[LeaderboardViewModel::class.java]
 
         setContent {
             TrivialQuizzTheme {
                 Scaffold(
                     modifier = Modifier.fillMaxSize()
                 ) { innerPadding ->
+                    val scores by leaderboardViewModel.scores.collectAsState()
                     LeaderboardScreen(
-                        scores = leaderboardViewModel.scores.value,
+                        scores = scores,
                         onClearScores = { leaderboardViewModel.clearScores() },
                         onBackClick = { finish() },
                         modifier = Modifier.padding(innerPadding)

--- a/app/src/main/java/com/supdevinci/trivialquizz/view/QuizActivity.kt
+++ b/app/src/main/java/com/supdevinci/trivialquizz/view/QuizActivity.kt
@@ -1,6 +1,5 @@
 package com.supdevinci.trivialquizz.view
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -11,15 +10,14 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import com.supdevinci.trivialquizz.model.Category
-import com.supdevinci.trivialquizz.model.ScoreEntry
 import com.supdevinci.trivialquizz.model.UserAnswer
 import com.supdevinci.trivialquizz.ui.theme.TrivialQuizzTheme
 import com.supdevinci.trivialquizz.viewmodel.QuizzViewModel
-import java.text.SimpleDateFormat
-import java.util.*
+import com.supdevinci.trivialquizz.viewmodel.LeaderboardViewModel
 
 class QuizActivity : ComponentActivity() {
     private val quizViewModel: QuizzViewModel by viewModels()
+    private val leaderboardViewModel: LeaderboardViewModel by viewModels()
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -98,28 +96,12 @@ class QuizActivity : ComponentActivity() {
         categoryName: String,
         difficultyDisplay: String
     ) {
-        // Calculate percentage
-        val percentage = (score * 100) / total
-        
-        // Format current date and time
-        val sdf = SimpleDateFormat("dd/MM/yyyy HH:mm:ss", Locale.getDefault())
-        val currentDateTime = sdf.format(Date())
-        
-        // Create score entry
-        val scoreEntry = ScoreEntry(
-            rank = 1, // This will be recalculated when displaying the leaderboard
-            player = playerName,
-            category = categoryName,
+        leaderboardViewModel.addScore(
+            playerName = playerName,
+            categoryName = categoryName,
             difficulty = difficultyDisplay,
-            score = "$score/$total",
-            percentage = percentage,
-            date = currentDateTime
+            correctAnswers = score,
+            totalQuestions = total
         )
-        
-        // TODO: Save score to database or shared preferences
-        // For now, we'll just pass it to LeaderboardActivity
-        val intent = Intent(this, LeaderboardActivity::class.java)
-        intent.putExtra("newScore", scoreEntry)
-        // Don't start the activity yet, just prepare the intent
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ gsonconverter = "2.9.0"
 coroutines = "1.3.5"
 lifecycleViewModel = "2.6.1"
 lifecycleViewModelCompose = "2.6.1"
+room = "2.5.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -47,9 +48,13 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewModel" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewModelCompose" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-parcelize = { id = "kotlin-parcelize" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- integrate Room dependencies
- store quiz scores in Room with ScoreEntity/DAO/Database
- expose data via ScoreRepository and use it in LeaderboardViewModel
- record scores from QuizActivity
- display leaderboard updates with Flow

## Testing
- `./gradlew test` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68511670f964832282e8e3926bd82bee